### PR TITLE
Minor README update to include Ubuntu specific prerequisite installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ For older versions, check the available [releases](../../releases).
 
 * Install **conky**, **curl** and **jq**.
 
+####Ubuntu
+```bash
+apt-get install conky conky-all curl jq
+```
+
 * Install the [Roboto & Roboto Light](https://www.google.com/fonts/specimen/Roboto) fonts.
 
 * Move the `.jelly-conky-icons` folder into your `~` dir.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For older versions, check the available [releases](../../releases).
 apt-get install conky conky-all curl jq
 ```
 
-* Install the [Roboto & Roboto Light](https://www.google.com/fonts/specimen/Roboto) fonts.
+* Install the [Roboto & Roboto Light](https://www.google.com/fonts/specimen/Roboto) fonts (Download pack from [FontSquirrel](https://www.fontsquirrel.com/fonts/roboto)).
 
 * Move the `.jelly-conky-icons` folder into your `~` dir.
 


### PR DESCRIPTION
This minor detail would help some of the users who would only read this README file to setup Jelly Conky. 